### PR TITLE
PEP_ページネーション機能の実装、投稿の最新順での表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ gem 'devise'
 gem 'pry-rails'
 
 gem 'font-awesome-rails'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,18 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -219,6 +231,7 @@ DEPENDENCIES
   devise
   font-awesome-rails
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -19,3 +19,12 @@
   margin-top: 30px;
   margin-bottom: 30px;
 }
+
+.paginate {
+  margin: auto;
+  background-color: white;
+  margin-bottom: 10px;
+  margin-top: 30px;
+  text-align: center;
+  font-weight: bold;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :set_post1, only: [:show, :edit]
   def index
-    @posts = Post.includes(:user)
+    @posts = Post.includes(:user).order("created_at DESC").page(params[:page]).per(5)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts
+    @posts = @user.posts.order("created_at DESC").page(params[:page]).per(5)
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,3 +16,6 @@
 <div class="content1">
   <div class="content1-box"></div>
 </div>
+<div class="paginate">
+  <%= paginate(@posts) %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,3 +20,6 @@
 <div class="content1">
   <div class="content1-box"></div>
 </div>
+<div class="paginate">
+  <%= paginate(@posts) %>
+</div>


### PR DESCRIPTION
[WHAT]
・ページネーション機能の実装
・投稿を最新順を上から表示するように設定
[WHY]
・ページが長文にならないように設定
・毎回古い投稿から始まっては使い勝手が悪いから。